### PR TITLE
Simplify the logic to connect with existing wallet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import {
   useConnect,
   useSendTransaction,
   http,
-  Connector,
 } from 'wagmi';
 import { embeddedWallet, userHasWallet } from '@civic/auth-web3';
 import { CivicAuthProvider, UserButton, useUser } from '@civic/auth-web3/react';
@@ -53,7 +52,7 @@ const AppContent = () => {
   // A function to connect an existing civic embedded wallet
   const connectExistingWallet = () => { 
     return connect({
-      connector: connectors.find(c => c.type === "civic") as Connector,
+      connector: connectors[0],
     });
   };
 


### PR DESCRIPTION
As Civic embedded wallet is the only connector, we can just connect to the first connector on the list, instead of looking for the Civic connector. This makes the sample app a bit easier to read.